### PR TITLE
Appropriately limit the chat input field length in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
     <!-- iChat stuff here -->
     <label for="iChat-input">iChat</label>
-    <input id="iChat-input" class="iChat iChat-input" placeholder="Chat here!">
+    <input id="iChat-input" class="iChat iChat-input" placeholder="Chat here!" minlength="2" maxlength="127">
     <div id="iChat-messages" class="iChat-messages iChat"></div>
     <script src="https://legend-of-iphoenix.github.io/iChat/js/iChat.min.js"></script>
     <script type="text/javascript" src="js/iChat-plugins.js"></script>


### PR DESCRIPTION
This just adds proper minlength/maxlength attributes to the HTML chat input box. Typing a message that's too long caused Enter/Return to do nothing at all, which is confusing. This makes it so the field simply won't accept any more characters if the message is too long, which makes it more obvious what's wrong and allows the user to tell when their message is short enough to fit.